### PR TITLE
FIX: Reading Base64 JWT conforming to RFC-4648

### DIFF
--- a/src/qjsonwebtoken.cpp
+++ b/src/qjsonwebtoken.cpp
@@ -201,6 +201,14 @@ QString QJsonWebToken::getToken()
 	return m_byteAllData + "." + byteSignatureBase64;
 }
 
+static QByteArray readBase64(QString strToken) {
+	// decode based on RFC-4648 URI safe encoding
+	strToken.replace('-', '+');
+	strToken.replace('_', '/');
+
+	return QByteArray::fromBase64(strToken.toUtf8());
+}
+
 bool QJsonWebToken::setToken(QString strToken)
 {
 	// assume base64 encoded at first, if not try decoding
@@ -214,8 +222,8 @@ bool QJsonWebToken::setToken(QString strToken)
 	// check all parts are valid using another instance,
 	// so we dont overwrite this instance in case of error
 	QJsonWebToken tempTokenObj;
-	if ( !tempTokenObj.setHeaderQStr(QByteArray::fromBase64(listJwtParts.at(0).toUtf8())) ||
-		 !tempTokenObj.setPayloadQStr(QByteArray::fromBase64(listJwtParts.at(1).toUtf8())) )
+	if ( !tempTokenObj.setHeaderQStr(readBase64(listJwtParts.at(0))) ||
+		!tempTokenObj.setPayloadQStr(readBase64(listJwtParts.at(1))) )
 	{
 		// try unencoded
 		if (!tempTokenObj.setHeaderQStr(listJwtParts.at(0)) ||
@@ -233,8 +241,8 @@ bool QJsonWebToken::setToken(QString strToken)
 	setPayloadQStr(tempTokenObj.getPayloadQStr());
 	if (isBase64Encoded)
 	{ // unencode
-		m_byteSignature = QByteArray::fromBase64(listJwtParts.at(2).toUtf8());
-	} 
+		m_byteSignature = readBase64(listJwtParts.at(2));
+	}
 	else
 	{
 		m_byteSignature = listJwtParts.at(2).toUtf8();

--- a/src/qjsonwebtoken.cpp
+++ b/src/qjsonwebtoken.cpp
@@ -223,7 +223,7 @@ bool QJsonWebToken::setToken(QString strToken)
 	// so we dont overwrite this instance in case of error
 	QJsonWebToken tempTokenObj;
 	if ( !tempTokenObj.setHeaderQStr(readBase64(listJwtParts.at(0))) ||
-		!tempTokenObj.setPayloadQStr(readBase64(listJwtParts.at(1))) )
+		 !tempTokenObj.setPayloadQStr(readBase64(listJwtParts.at(1))) )
 	{
 		// try unencoded
 		if (!tempTokenObj.setHeaderQStr(listJwtParts.at(0)) ||


### PR DESCRIPTION
Turns out that JWT uses a URL-safe form of base64 that is slightly different (described in [RFC-4648](https://tools.ietf.org/html/rfc4648#page-7)). Our application failed to read such a JWT (see below) for this reason. Please compare the following (officially endorsed) implementation of JWT in C: https://github.com/benmcollins/libjwt/blob/master/libjwt/jwt.c#L264

For reference: The token that failed to parse with this library:
```
eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjYjk4N2RjNS0yY2UzLTRlMjAtOTRiZS1kZWFjMzMxOWJkOGU
iLCJ1c2VyX2VtYWlsIjoibW9wcy5ncm9zc2VAbmV4ZW5pby5jb20iLCJ1c2VyX3Jvb3R0cmVlbm9kZWl
kIjoiN2ZhZWYzODctNDM1Mi00YjYzLTg2Y2UtODU5NDAyZWE4ZjI3IiwiY29tcGFueV9pZCI6IjkyMDF
mYWVlLTRiOTYtNDZkYi04MWYxLTcxMjExMTBmN2ZiNyIsInVzZXJfbmFtZSI6Ik1vcHMgZGVyIEdyb8O
fZSIsImNvbXBhbnlfYWN0aXZlIjp0cnVlLCJpc3MiOiJDbG91ZFJhaWQgU2VydmVyIiwicmVmcmVzaF9
leHBpcnkiOjE1MTI2MjkyMjMsInVzZXJfcm9sZXMiOlsiVVNFUiJdLCJyZWZyZXNoX3Rva2VuIjoiSWd
TM1FIY3paa3dyQjhZMk8zUG1KQjBPeFNBT2gzb09JYldTLWNzc1hNSSIsInVzZXJfZ2l2ZW5uYW1lIjo
iTW9wcyIsInVzZXJfaWQiOiJjYjk4N2RjNS0yY2UzLTRlMjAtOTRiZS1kZWFjMzMxOWJkOGUiLCJleHA
iOjE1MTI1OTMyMjMsInRva2VuVHlwZSI6IkFVVEhFTlRJQ0FURURfVVNFUl9UT0tFTiIsInVzZXJfZmF
taWx5bmFtZSI6ImRlciBHcm_Dn2UifQ.6INfl7V03Sltz6eweU6NmcOY7Cng_H90sJhUjDv7TnIeyJhb
GciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
```